### PR TITLE
fixing some prop-types errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.idea
 node_modules

--- a/src/components/Formsy.js
+++ b/src/components/Formsy.js
@@ -21,7 +21,7 @@ class Formsy extends React.Component {
     onValid: PropTypes.func,
     onValidSubmit: PropTypes.func,
     preventExternalInvalidation: PropTypes.bool,
-    validationErrors: PropTypes.node,
+    validationErrors: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/components/withFormsy.js
+++ b/src/components/withFormsy.js
@@ -8,10 +8,10 @@ function withFormsy(Component) {
 
     static propTypes = {
       value: PropTypes.string,
-      validations: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
+      validations: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
       required: PropTypes.bool,
       name: PropTypes.string.isRequired,
-      innerRef: PropTypes.oneOfType(PropTypes.func, PropTypes.string),
+      innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     };
 
     static contextTypes = {


### PR DESCRIPTION
 - updated Formsy.Form validationErrors prop type to be object, as the code later expects
 - updated WrappedComponent validations and innerRef oneOfType prop types to be an array of types, as expected